### PR TITLE
fix: gpg import

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 if [[ -f "${GPG_KEY}" ]]; then
 	echo "importing gpg key..."
-	if gpg --allow-secret-key-import --import "${GPG_KEY}"; then
+	if gpg --batch --import "${GPG_KEY}"; then
 		gpg --list-secret-keys --keyid-format long
 	fi
 fi


### PR DESCRIPTION
This commit removes the obsolete `--allow-secret-key-import` option from the gpg call, and
adds `--batch` to prevent errors when importing the secret key.

Before fix:

```
importing gpg key...
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key FFFFFFFFFFFFFFFF: public key "John Doe <john@example.org>" imported
gpg: key FFFFFFFFFFFFFFFF/FFFFFFFFFFFFFFFF: error sending to agent: Inappropriate ioctl for device
gpg: error building skey array: Inappropriate ioctl for device
gpg: error reading '/secrets/key.gpg': Inappropriate ioctl for device
gpg: import from '/secrets/key.gpg' failed: Inappropriate ioctl for device
gpg: Total number processed: 0
gpg:               imported: 1
gpg:       secret keys read: 1
```

After fix:

```
importing gpg key...
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key FFFFFFFFFFFFFFFF: public key "John Doe <john@example.org>" imported
gpg: key FFFFFFFFFFFFFFFF: secret key imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg:       secret keys read: 1
gpg:   secret keys imported: 1
/root/.gnupg/pubring.kbx
------------------------
sec   rsa3072/FFFFFFFFFFFFFFFF 2021-04-08 [SC]
      FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
uid                 [ unknown] John Doe <john@example.org>
ssb   rsa3072/FFFFFFFFFFFFFFFF 2021-04-08 [E]
```
